### PR TITLE
fix multiword searches from menu

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -415,7 +415,7 @@ stream() {
 	else
 		get_search_query "$*"
 	fi
-	anime_id="${query// /}"
+	anime_id="$query"
 	[ -z "$anime_id" ] && die "No anime selected or queried"
 	searched=0
 	lg "Checking if anime: $anime_id has been searched before..."

--- a/lib/ani-cli/UI
+++ b/lib/ani-cli/UI
@@ -128,6 +128,7 @@ get_search_query() {
 	else
 		prompt "Search Anime"
 		read -r query
+		query="${query// /-}"
 	fi
 }
 

--- a/lib/ani-cli/UI-ROFI
+++ b/lib/ani-cli/UI-ROFI
@@ -173,7 +173,8 @@ get_search_query() {
 		query=$(rofi -dpi "$DPI" -dmenu -l 15 -p "Search Anime:" \
 			-mesg "$(generate_span "$msg")" \
 			-config "$ROFI_CFG" -window-title 'aniwrapper' < <(run_stmt "$stmt"))
-		query="${query//[1-9]*\. /}"
+		query="${query#*\. }" # remove [1-9]. from beginning of query
+		query="${query// /-}" # replace spaces with -
 	fi
 }
 


### PR DESCRIPTION
Replace spaces with dashes when parsing multi-word search queries

Solves #9 